### PR TITLE
fix: fix dingtalk/jdk.tools dependency problem, change conjars repo url to https

### DIFF
--- a/mma-commons/pom.xml
+++ b/mma-commons/pom.xml
@@ -51,6 +51,12 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-metastore</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>jdk.tools</groupId>
+          <artifactId>jdk.tools</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/mma-server/pom.xml
+++ b/mma-server/pom.xml
@@ -44,6 +44,12 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-jdbc</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.jetty.aggregate</groupId>
+          <artifactId>jetty-all</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -106,8 +112,8 @@ limitations under the License.
       <artifactId>jgrapht-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.dingtalk</groupId>
-      <artifactId>dingtalk-sdk</artifactId>
+      <groupId>com.aliyun</groupId>
+      <artifactId>alibaba-dingtalk-service-sdk</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/mma-server/pom.xml
+++ b/mma-server/pom.xml
@@ -44,12 +44,6 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-jdbc</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.eclipse.jetty.aggregate</groupId>
-          <artifactId>jetty-all</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@ limitations under the License.
     <repository>
       <id>conjars</id>
       <name>Concurrent Conjars repository</name>
-      <url>http://conjars.org/repo</url>
+      <url>https://conjars.org/repo</url>
       <layout>default</layout>
     </repository>
   </repositories>
@@ -199,9 +199,9 @@ limitations under the License.
       </dependency>
       <!-- dingtalk sdk -->
       <dependency>
-        <groupId>com.dingtalk</groupId>
-        <artifactId>dingtalk-sdk</artifactId>
-        <version>1.0</version>
+        <groupId>com.aliyun</groupId>
+        <artifactId>alibaba-dingtalk-service-sdk</artifactId>
+        <version>1.0.1</version>
       </dependency>
       <!-- jetty -->
       <dependency>

--- a/sql-checker/pom.xml
+++ b/sql-checker/pom.xml
@@ -84,6 +84,10 @@ limitations under the License.
           <artifactId>jsr305</artifactId>
           <groupId>com.google.code.findbugs</groupId>
         </exclusion>
+        <exclusion>
+          <groupId>jdk.tools</groupId>
+          <artifactId>jdk.tools</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
Fix some pom dependency problem:
1. Change parent repo url from http://conjars.org/repo to https://conjars.org/repo,  Maven blocks external HTTP repositories by default since version 3.8.1;
2. Change dingtalk sdk from com.dingtalk.dingtalk-sdk to com.aliyun.alibaba-dingtalk-service-sdk, can't find former dingtalk-sdk from maven central repository;
3. Exclude jdk.tools from hive-metastore, which cause compile error with jdk 11 or newer;
4. Exclude older jetty-all 7.x from hive-jdbc which cause jetty constructor conflict in MmaJettyServer.java