### PR TITLE
exitSwitchDatabaseStatement

### DIFF
--- a/sql-checker/src/main/java/com/aliyun/odps/compiler/TableIdentifierListener.java
+++ b/sql-checker/src/main/java/com/aliyun/odps/compiler/TableIdentifierListener.java
@@ -43,6 +43,13 @@ public class TableIdentifierListener extends OdpsParserBaseListener {
     this.hiveMetaCache = Objects.requireNonNull(hiveMetaCache);
   }
 
+
+  @Override
+  public void exitSwitchDatabaseStatement(odpsParser.SwitchDatabaseStatementContext ctx) {
+    super.exitSwitchDatabaseStatement(ctx);
+    this.defaultProjectName = ctx.identifier().getText();
+  }
+
   @Override
   public void exitCteStatement(CteStatementContext ctx) {
     super.exitCteStatement(ctx);


### PR DESCRIPTION
具体在用sql-checker工具时发现总是报：默认库中表没有的错误。看代码发现，代码逻辑有误，在拉取元数据缓存的时候，没有拉到了正确的库，导致在解析时候，在正确的库里找不到表